### PR TITLE
'display1' is deprecated and shouldn't be used

### DIFF
--- a/custom_paint_example/lib/home.dart
+++ b/custom_paint_example/lib/home.dart
@@ -32,7 +32,7 @@ class _MyHomePageState extends State<MyHomePage> {
               ),
               Text(
                 '$_counter',
-                style: Theme.of(context).textTheme.display1,
+                style: Theme.of(context).textTheme.headline4,
               ),
             ],
           ),


### PR DESCRIPTION
'display1' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is headline4. This feature was deprecated after v1.13.8..